### PR TITLE
Refactoring code, reorganizing module structure

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+
+[*.{js,json}]
+indent_size = 2
+
+[{package.json, .eslintrc}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,18 +4,13 @@
     "indent": [ "error", 2 ],
     "no-alert": [ "off" ],
     "curly": [ "error", "multi-line" ],
+    "template-curly-spacing": [ "error", "always" ],
     "object-curly-spacing": [ "error", "always", {
       "arraysInObjects": false,
       "objectsInObjects": false
     }]
   },
   "env": {
-    "browser": true,
     "node": true
-  },
-  "globals": {
-    "$": false,
-    "multiline": false,
-    "lodash": false
   }
 }

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function toUpper(str) {
+  str = str || '';
+  return str.toUpperCase();
+}
+
+function toFloat(str) {
+  if (!str || !str.length) return 0;
+  return str.replace(',', '.');
+}
+
+module.exports = {
+  toUpper,
+  toFloat
+};

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "CLI currency converter",
   "main": "server.js",
   "bin": {
-    "convert": "cli.js",
+    "conv": "cli.js",
     "hpb": "cli.js"
-
   },
   "scripts": {
     "start": "node cli.js"
@@ -16,5 +15,9 @@
   "dependencies": {
     "log-symbols": "^1.0.2",
     "request": "^2.74.0"
+  },
+  "devDependencies": {
+    "eslint": "^3.5.0",
+    "eslint-config-xo": "^0.15.4"
   }
 }

--- a/parser.js
+++ b/parser.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const request = require('request');
+const toFloat = require('./helpers.js').toFloat;
+
+const url = 'http://www.hnb.hr/hnb-tecajna-lista-portlet/rest/tecajn/getformatedrecords.dat';
+const hrk = { curr: 'HRK', unit: 1, buy: 1, avg: 1, sell: 1 };
+
+function parseLine(line) {
+  // Swap consequtive spaces by tabs and split by them.
+  let columns = line.replace(/\s+/g, '\t').split('\t');
+
+  // Parse first column, that has following format:
+  // |digit code|currency code|unit| - all sections are 3 chars wide
+  let first = columns[0];
+  let curr = first.substring(3, 6);
+  let unit = parseInt(first.substring(6, 9), 10);
+
+  // Parse following 3 columns.
+  let buy = toFloat(columns[1]);
+  let avg = toFloat(columns[2]);
+  let sell = toFloat(columns[3]);
+
+  // Create and return exchange record.
+  return { curr, unit, buy, avg, sell };
+}
+
+function getExchangeRecords() {
+  return new Promise((resolve, reject) => {
+    request(url, (err, resp, data) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      let records = { [hrk.curr]: hrk };
+      data.split('\n').slice(1).forEach(line => {
+        let record = parseLine(line);
+        records[record.curr] = record;
+      });
+
+      resolve(records);
+    });
+  });
+}
+
+module.exports = getExchangeRecords;


### PR DESCRIPTION
This PR brings several code refactorings plus structural reorganization of module. Most of the work is done in order to leverage ES6 as much as possible and to better modularize stuff. It also fixes #1 by renaming binary from `convert` to `conv`.