### PR TITLE
Migrating to node@6

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,10 +3,7 @@
 'use strict';
 
 const getExchangeRecords = require('./parser.js');
-const helpers = require('./helpers.js');
-const toUpper = helpers.toUpper;
-const toFloat = helpers.toFloat;
-const parseArgs = helpers.parseArgs;
+const { toUpper, toFloat, parseArgs } = require('./helpers.js');
 
 // Parse user input. [ amount source _ dest ]
 let args = process.argv.slice(2);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "scripts": {
     "start": "node cli.js"
   },
+  "engines": {
+    "node": ">=6"
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/parser.js
+++ b/parser.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const request = require('request');
-const toFloat = require('./helpers.js').toFloat;
+const { toFloat } = require('./helpers.js');
 
 const url = 'http://www.hnb.hr/hnb-tecajna-lista-portlet/rest/tecajn/getformatedrecords.dat';
 const hrk = { curr: 'HRK', unit: 1, buy: 1, avg: 1, sell: 1 };


### PR DESCRIPTION
Dropping support for older versions of node in order to leverage ES6 destructuring assignments.